### PR TITLE
fix: Arweave init

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
   ],
   "exports": {
     ".": {
-      "require": "./dist/index.js",
+      "require": "./dist/index.cjs",
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     }
   },
-  "main": "dist/index.js",
+  "main": "dist/index.cjs",
   "module": "dist/index.js",
   "unpkg": "dist/index.global.js",
   "jsdelivr": "dist/index.global.js",

--- a/src/utils/arweaveInstance.ts
+++ b/src/utils/arweaveInstance.ts
@@ -1,6 +1,8 @@
 import Arweave from 'arweave'
 
-export const arweaveInstance = Arweave.init({
+const ArweaveClass: typeof Arweave = (Arweave as any)?.default ?? Arweave
+
+export const arweaveInstance = ArweaveClass.init({
   host: 'arweave.net',
   port: 443,
   protocol: 'https'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,9 +25,9 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module": "commonjs" /* Specify what module code is generated. */,
+    "module": "ESNext" /* Specify what module code is generated. */,
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
+    "moduleResolution": "node" /* Specify how TypeScript looks up a file from a given module specifier. */,
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
@@ -76,7 +76,7 @@
     /* Interop Constraints */
     // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
     // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
-    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+    "allowSyntheticDefaultImports": true /* Allow 'import x from y' when a module doesn't have a default export. */,
     "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
     // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
     "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,


### PR DESCRIPTION
## Summary

This PR fixes the issue with Arweave initialization `Arweave.init`.

I tried different ts configs but it didn't work so i added this code to fix the issue:

```ts
const ArweaveClass: typeof Arweave = (Arweave as any)?.default ?? Arweave

export const arweaveInstance = ArweaveClass.init({
  host: 'arweave.net',
  port: 443,
  protocol: 'https'
})
```